### PR TITLE
Fixes #15 deploys master branch to google cloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+sudo: required
+# Use node_js environnement
+language: java
+
+# Cache Gcloud SDK between commands
+
+cache:
+  directories:
+    - "$HOME/google-cloud-sdk/"
+
+# Install services
+services:
+  - docker
+
+# Set env vars
+env:
+  global:
+    - GOOGLE_APPLICATION_CREDENTIALS=~/gcloud-service-key.json
+    - PROJECT_NAME_STG=yacygrid
+    - CLUSTER_NAME_STG=cluster-1
+    - CLOUDSDK_COMPUTE_ZONE=us-central1-a
+    - DOCKER_IMAGE_NAME=yacygridmcp
+    - KUBE_DEPLOYMENT_NAME=yacygridmcp
+    - KUBE_DEPLOYMENT_CONTAINER_NAME=yacygridmcp
+    - NODE_ENV=CI
+
+
+script:
+  - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
+  - source /home/travis/google-cloud-sdk/path.bash.inc
+  - gcloud --quiet version
+  - gcloud --quiet components update
+  - gcloud --quiet components update kubectl
+  - bash ./deploy_staging.sh
+
+branches:
+   only:
+   - master

--- a/cloud.yaml
+++ b/cloud.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yacygridmcp
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: yacygridmcp
+    spec:
+      containers:
+      - name: yacygridmcp
+        image: gcr.io/yacygrid/yacygridmcp
+        ports:
+        - containerPort: 8080

--- a/deploy_staging.sh
+++ b/deploy_staging.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+docker build -t nikhilrayaprolu/yacygridmcp:$TRAVIS_COMMIT ./docker
+docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+docker push nikhilrayaprolu/yacygridmcp
+echo $GCLOUD_SERVICE | base64 --decode -i > ${HOME}/gcloud-service-key.json
+cat ${HOME}/gcloud-service-key.json
+gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json
+
+gcloud --quiet config set project $PROJECT_NAME_STG
+gcloud --quiet config set container/cluster $CLUSTER_NAME_STG
+gcloud --quiet config set compute/zone ${CLOUDSDK_COMPUTE_ZONE}
+gcloud --quiet container clusters get-credentials $CLUSTER_NAME_STG
+
+
+kubectl config view
+kubectl config current-context
+
+kubectl set image deployment/${KUBE_DEPLOYMENT_NAME} ${KUBE_DEPLOYMENT_CONTAINER_NAME}=nikhilrayaprolu/yacygridmcp:$TRAVIS_COMMIT
+
+# sleep 30
+# npm run e2e_test

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,10 +32,11 @@ RUN tar xf rabbitmq-server-generic-unix-3.6.6.tar.xz
 # install erlang language for RabbitMQ
 RUN apt-get install -y erlang
 
+RUN wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.0.tar.gz
+RUN sha1sum elasticsearch-5.5.0.tar.gz 
+RUN tar -xzf elasticsearch-5.5.0.tar.gz
 
-
-
-ADD .. /yacy_grid_mcp
+RUN git clone https://github.com/nikhilrayaprolu/yacy_grid_mcp.git
 WORKDIR /yacy_grid_mcp
 
 RUN cat docker/config-ftp.properties > ../apache-ftpserver-1.1.0/res/conf/users.properties
@@ -43,13 +44,14 @@ RUN cat docker/config-ftp.properties > ../apache-ftpserver-1.1.0/res/conf/users.
 
 # compile
 RUN gradle build
+RUN mkdir data/mcp-8100/conf/ -p
 RUN cp docker/config-mcp.properties data/mcp-8100/conf/config.properties
 RUN chmod +x ./docker/start.sh
 # Expose web interface ports
 # 2121: ftp, a FTP server to be used for mass data / file storage
 # 5672: rabbitmq, a rabbitmq message queue server to be used for global messages, queues and stacks
 # 9300: elastic, an elasticsearch server or main cluster address for global database storage
-EXPOSE 2121 5672 9300
+EXPOSE 2121 5672 9300 9200 15672 8100
 
 
 # Define default command.

--- a/docker/config-mcp.properties
+++ b/docker/config-mcp.properties
@@ -22,7 +22,7 @@ grid.ftp.address = yacygrid:password4account@localhost:2121
 grid.broker.address = yacygrid:password4account@localhost:5672
 
 # the address of the elasticsearch transport client instance(s)
-grid.elasticsearch.address = elasticsearch:9300
+grid.elasticsearch.address = localhost:9300
 grid.elasticsearch.clusterName = yacygrid
 
 grid.elasticsearch.webIndexName = web

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -6,6 +6,7 @@ sleep 5s;
 /rabbitmq_server-3.6.6/sbin/rabbitmqctl add_user yacygrid password4account
 echo [{rabbit, [{loopback_users, []}]}]. >> /rabbitmq_server-3.6.6/etc/rabbitmq/rabbitmq.config
 /rabbitmq_server-3.6.6/sbin/rabbitmqctl set_permissions -p / yacygrid ".*" ".*" ".*"
+elasticsearch-5.5.0/bin/elasticsearch -d -p pid -Ecluster.name=yacygrid
 cd /yacy_grid_mcp
 sleep 5s;
 gradle run


### PR DESCRIPTION
fixes #15 
Made all changes required for the deployment and got the container working on google cloud, I have tested this on my own repo, and got it working. related travis report is at https://travis-ci.org/nikhilrayaprolu/yacy_grid_mcp .

One needs admin account to add authentication keys google cloud.
![image](https://user-images.githubusercontent.com/15216503/28247707-8c988158-6a53-11e7-8d8b-b339ad5958e4.png)

the deployment address is at http://130.211.167.207:8100/

