### PR TITLE
Fixes #18 Now Yacy is able to connect with elastic search

### DIFF
--- a/deploy_staging.sh
+++ b/deploy_staging.sh
@@ -6,7 +6,6 @@ docker build -t nikhilrayaprolu/yacygridmcp:$TRAVIS_COMMIT ./docker
 docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 docker push nikhilrayaprolu/yacygridmcp
 echo $GCLOUD_SERVICE | base64 --decode -i > ${HOME}/gcloud-service-key.json
-cat ${HOME}/gcloud-service-key.json
 gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json
 
 gcloud --quiet config set project $PROJECT_NAME_STG

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,4 +1,9 @@
-cd /apache-ftpserver-1.1.0 
+adduser --disabled-password --gecos '' r
+adduser r sudo
+echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+chmod a+rwx /elasticsearch-5.5.0 -R
+su -m r -c '/elasticsearch-5.5.0/bin/elasticsearch -Ecluster.name=yacygrid &'
+cd /apache-ftpserver-1.1.0
 ./bin/ftpd.sh res/conf/ftpd-typical.xml &
 /rabbitmq_server-3.6.6/sbin/rabbitmq-server -detached
 sleep 5s;
@@ -6,7 +11,6 @@ sleep 5s;
 /rabbitmq_server-3.6.6/sbin/rabbitmqctl add_user yacygrid password4account
 echo [{rabbit, [{loopback_users, []}]}]. >> /rabbitmq_server-3.6.6/etc/rabbitmq/rabbitmq.config
 /rabbitmq_server-3.6.6/sbin/rabbitmqctl set_permissions -p / yacygrid ".*" ".*" ".*"
-elasticsearch-5.5.0/bin/elasticsearch -d -p pid -Ecluster.name=yacygrid
 cd /yacy_grid_mcp
 sleep 5s;
 gradle run


### PR DESCRIPTION
fixes #18 
**before**
![screenshot from 2017-07-18 15-34-18](https://user-images.githubusercontent.com/15216503/28316545-e7ad77a4-6be0-11e7-896f-f72bdfb69c2f.png)

made changes so that elastic search starts without any errors
**After** Yacygrid is able to get connected with elastic search, message broker and asset storage successfully
![screenshot from 2017-07-18 17-41-16](https://user-images.githubusercontent.com/15216503/28316595-19fd904a-6be1-11e7-9586-61c2639fdd0f.png)

tested Yacy endpoint by sending asset storage messages and successfully checked the asset file.
![screenshot from 2017-07-18 17-40-56](https://user-images.githubusercontent.com/15216503/28316635-44f85708-6be1-11e7-801b-8eb7f1817ffc.png)

The active endpoint for the deployment is available at http://130.211.167.207:8100/