### PR TITLE
Updated Readme.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ ftpserver.user.yacygrid.downloadrate=0
 - run the server, doing:
 
     > cd apache-ftpserver-1.1.0
+    
     > bin/ftpd.sh res/conf/ftpd-typical.xml
     
 This will run the ftp server at port 2121. To test the connection use a standard ftp client and start it with


### PR DESCRIPTION
The two commands are displayed as one when viewing Readme.md in github.com. 
![image](https://user-images.githubusercontent.com/10105332/54474527-e24c4480-480b-11e9-89ab-3a726d8fd356.png)

Hence I have entered a newline between them