### PR TITLE
Bump version of Apache FTP Server to 1.1.1 since 1.1.0 has disappeared

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN tar -xzf elasticsearch-5.5.0.tar.gz
 RUN git clone https://github.com/nikhilrayaprolu/yacy_grid_mcp.git
 WORKDIR /yacy_grid_mcp
 
-RUN cat docker/config-ftp.properties > ../apache-ftpserver-1.1.0/res/conf/users.properties
+RUN cat docker/config-ftp.properties > ../apache-ftpserver-1.1.1/res/conf/users.properties
 
 
 # compile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,9 +21,9 @@ RUN PATH=$PATH:/opt/gradle/gradle-3.4.1/bin
 ENV GRADLE_HOME=/opt/gradle/gradle-3.4.1
 ENV PATH=$PATH:$GRADLE_HOME/bin
 RUN gradle -v
-# install apache ftp server 1.1.0
-RUN wget http://www-eu.apache.org/dist/mina/ftpserver/1.1.0/dist/apache-ftpserver-1.1.0.tar.gz
-RUN tar xfz apache-ftpserver-1.1.0.tar.gz
+# install apache ftp server 1.1.1
+RUN wget http://www-eu.apache.org/dist/mina/ftpserver/1.1.1/dist/apache-ftpserver-1.1.1.tar.gz
+RUN tar xfz apache-ftpserver-1.1.1.tar.gz
 
 # install RabbitMQ server
 RUN wget https://www.rabbitmq.com/releases/rabbitmq-server/v3.6.6/rabbitmq-server-generic-unix-3.6.6.tar.xz


### PR DESCRIPTION
Apache FTP Server 1.1.0 no longer exists. Updating to 1.1.1.

http://www-eu.apache.org/dist/mina/ftpserver/1.1.1/dist/