### PR TITLE
Update ElasticSearch client library to 7.10+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@
 # curl http://localhost:8100/yacy/grid/mcp/info/status.json
 
 ## build app
-FROM eclipse-temurin:8-jdk-alpine AS appbuilder
+FROM eclipse-temurin:11-jdk-alpine AS appbuilder
 COPY ./ /app
 WORKDIR /app
 RUN ./gradlew clean shadowDistTar
 
 ## build dist
-FROM eclipse-temurin:8-jre-alpine
+FROM eclipse-temurin:11-jre-alpine
 LABEL maintainer="Michael Peter Christen <mc@yacy.net>"
 ENV DEBIAN_FRONTEND noninteractive
 ARG default_branch=master

--- a/Dockerfile_arm32
+++ b/Dockerfile_arm32
@@ -10,13 +10,13 @@
 # curl http://localhost:8100/yacy/grid/mcp/info/status.json
 
 ## build app
-FROM arm32v7/eclipse-temurin:8-jdk AS appbuilder
+FROM arm32v7/eclipse-temurin:11-jdk AS appbuilder
 COPY ./ /app
 WORKDIR /app
 RUN ./gradlew assemble
 
 ## build dist
-FROM arm32v7/eclipse-temurin:8-jre
+FROM arm32v7/eclipse-temurin:11-jre
 LABEL maintainer="Michael Peter Christen <mc@yacy.net>"
 ENV DEBIAN_FRONTEND noninteractive
 ARG default_branch=master

--- a/Dockerfile_arm64
+++ b/Dockerfile_arm64
@@ -10,13 +10,13 @@
 # curl http://localhost:8100/yacy/grid/mcp/info/status.json
 
 ## build app
-FROM arm64v8/eclipse-temurin:8-jdk AS appbuilder
+FROM arm64v8/eclipse-temurin:11-jdk AS appbuilder
 COPY ./ /app
 WORKDIR /app
 RUN ./gradlew assemble
 
 ## build dist
-FROM arm64v8/eclipse-temurin:8-jre
+FROM arm64v8/eclipse-temurin:11-jre
 LABEL maintainer="Michael Peter Christen <mc@yacy.net>"
 ENV DEBIAN_FRONTEND noninteractive
 ARG default_branch=master

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'org.eclipse.jetty:jetty-server:9.4.+'
     implementation 'org.eclipse.jetty:jetty-servlet:9.4.+'
     implementation 'org.eclipse.jgit:org.eclipse.jgit:5.+'
-    implementation 'org.elasticsearch.client:transport:6.8.+'
+    implementation 'org.elasticsearch.client:transport:7.10.+'
     implementation 'org.mapdb:mapdb:3.+'
     implementation 'org.slf4j:log4j-over-slf4j:1.7.+'
     implementation 'org.slf4j:slf4j-jdk14:1.7.+'

--- a/src/main/java/net/yacy/grid/io/index/ElasticIndexFactory.java
+++ b/src/main/java/net/yacy/grid/io/index/ElasticIndexFactory.java
@@ -211,7 +211,6 @@ public class ElasticIndexFactory implements IndexFactory {
                     }
                 } else if (language == QueryLanguage.elastic) {
                     QueryStringQueryBuilder qsqb = QueryBuilders.queryStringQuery(query);
-                    qsqb.useDisMax(false); // we want a boolean query here
                     qsqb.defaultOperator(Operator.AND);
                     qsqb.fuzziness(Fuzziness.ZERO);
                     qb = qsqb;

--- a/src/main/java/net/yacy/grid/io/index/ElasticsearchClient.java
+++ b/src/main/java/net/yacy/grid/io/index/ElasticsearchClient.java
@@ -310,7 +310,7 @@ public class ElasticsearchClient {
 
     public long countInternal(final QueryBuilder q, final String indexName) {
         SearchResponse response = this.elasticsearchClient.prepareSearch(indexName).setQuery(q).setSize(0).execute().actionGet();
-        return response.getHits().getTotalHits();
+        return response.getHits().getTotalHits().value;
     }
 
     /**
@@ -754,7 +754,7 @@ public class ElasticsearchClient {
             // get response
             SearchResponse response = request.execute().actionGet();
             SearchHits searchHits = response.getHits();
-            this.hitCount = (int) searchHits.getTotalHits();
+            this.hitCount = (int) searchHits.getTotalHits().value;
 
             // evaluate search result
             //long totalHitCount = response.getHits().getTotalHits();


### PR DESCRIPTION
This PR updates the ElasticSearch client library to 7.10+; this allows you to use current Elasticsearch/Opensearch stacks as opposed to the massively outdated 5.x/6.x branches.

This PR also updates JRE/JDK to 11. 